### PR TITLE
Issue with excluded/readonly fields

### DIFF
--- a/mongodbforms/documents.py
+++ b/mongodbforms/documents.py
@@ -253,7 +253,7 @@ def fields_for_document(document, fields=None, exclude=None, widgets=None,
     if fields:
         field_dict = OrderedDict(
             [(fi, field_dict.get(fi)) for fi in fields
-                if ((not exclude) or (exclude and f not in exclude))]
+                if ((not exclude) or (exclude and fi not in exclude))]
         )
 
     return field_dict


### PR DESCRIPTION
Hi @thomwiggers,

I noticed a very harmful issue due to a typo. Here is the symptom:

```
Traceback:
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  132.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/django/contrib/admin/options.py" in wrapper
  618.                 return self.admin_site.admin_view(view)(*args, **kwargs)
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  110.                     response = view_func(request, *args, **kwargs)
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
  57.         response = view_func(request, *args, **kwargs)
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/django/contrib/admin/sites.py" in inner
  233.             return view(request, *args, **kwargs)
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/django/contrib/admin/options.py" in change_view
  1521.         return self.changeform_view(request, object_id, form_url, extra_context)
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapper
  34.             return bound_func(*args, **kwargs)
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  110.                     response = view_func(request, *args, **kwargs)
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/django/utils/decorators.py" in bound_func
  30.                 return func.__get__(self, type(self))(*args2, **kwargs2)
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/django/utils/decorators.py" in inner
  145.                     return func(*args, **kwargs)
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/django/contrib/admin/options.py" in changeform_view
  1458.         ModelForm = self.get_form(request, obj)
File "/home/vagrant/work4us/venv/lib/python2.7/site-packages/mongoadmin/options.py" in get_form
  295.                              % (e, self.__class__.__name__))

Exception Type: FieldError at /admin/app/model/5633e0733d1338058424ac5a/
Exception Value: Unknown field(s) (field1, field2, field3, field4, field5) specified for MyModel. Check fields/fieldsets/exclude attributes of class MyModelAdmin.
```

Also, it would have been avoided with unit tests. I know you wrote some (thanks) but didn't have time to look at them. We might want to cover this :)
