### PR TITLE
BaseDocumentForm should instantiate new document if instance=None

### DIFF
--- a/mongodbforms/documents.py
+++ b/mongodbforms/documents.py
@@ -350,7 +350,7 @@ class BaseDocumentForm(BaseForm):
             if opts.document is None:
                 raise ValueError('A document class must be provided.')
             # if we didn't get an instance, instantiate a new one
-            self.instance = opts.document
+            self.instance = opts.document()
             object_data = {}
         else:
             self.instance = instance


### PR DESCRIPTION
Hi @thomwiggers,

A small fix that breaks instantiation of `DocumentForm`s with `instance=None`. I discovered it when migrating to Django 1.9.8. I don't know if it is really triggered by the version change, but this looks pretty serious...

Cheers!
